### PR TITLE
fix: remove unused @privy-io/wagmi-connector to resolve build error

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@privy-io/react-auth": "^3.6.0",
-        "@privy-io/wagmi-connector": "^0.1.13",
         "@rainbow-me/rainbowkit": "^2.2.0",
         "@tanstack/react-query": "^5.51.0",
         "lucide-react": "^0.552.0",
@@ -2364,19 +2363,6 @@
       "resolved": "https://registry.npmjs.org/@privy-io/urls/-/urls-0.0.2.tgz",
       "integrity": "sha512-v1LpojKGG9iiFO4HS3kDQ9o2WSf3VGLu9pdAwDuXhnKlHEQ+V2sHtrsA0ZNhC33EhufD7ZOcquAbfG7FxKsQXA==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@privy-io/wagmi-connector": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@privy-io/wagmi-connector/-/wagmi-connector-0.1.13.tgz",
-      "integrity": "sha512-dbel4pYvbJM+28m12DE7LvEKzJ8ni/rDkuHpF3RGwkph+HsgDNDxJy4OTgUjaKi6yJsjZ5nvhsZdNNVXbVFKkg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@privy-io/react-auth": "^1.33.0",
-        "react": "^18",
-        "react-dom": "^18",
-        "viem": ">=0.3.35",
-        "wagmi": ">=1.4.12 <2"
-      }
     },
     "node_modules/@rainbow-me/rainbowkit": {
       "version": "2.2.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@privy-io/react-auth": "^3.6.0",
-    "@privy-io/wagmi-connector": "^0.1.13",
     "@rainbow-me/rainbowkit": "^2.2.0",
     "@tanstack/react-query": "^5.51.0",
     "lucide-react": "^0.552.0",


### PR DESCRIPTION
- Remove @privy-io/wagmi-connector which conflicts with @privy-io/react-auth v3
- Package was not being used in codebase (using standard wagmi instead)
- Fixes Vercel build error: ERESOLVE dependency conflict